### PR TITLE
Fix type instablity in const.jl and split.jl

### DIFF
--- a/src/const.jl
+++ b/src/const.jl
@@ -1,5 +1,5 @@
-using MIDI:Notes
-
+import MIDI.Note
+const Notes = MIDI.Notes{MIDI.Note}
 @enum Hand lh=-1 rh=1
 @enum Finger f1=1 f2=2 f3=3 f4=4 f5=5
 @enum Direct up=1 down=-1 level=0

--- a/src/split.jl
+++ b/src/split.jl
@@ -31,8 +31,8 @@ function split_notes(notes_by_position::Vector{Notes},hand::Hand)::Vector{Int}
             left = i - offset
             right = i + offset
             if left >= 1 && right <= len
-                push!(s,notes_by_position[left]...)
-                push!(s,notes_by_position[right]...)
+                union!(s, notes_by_position[left].notes)
+                union!(s, notes_by_position[right].notes)
                 if max_notes[i] < max_notes[left] || max_notes[i] < max_notes[right]
                     is_max = false
                     break


### PR DESCRIPTION
I didn't run the test cause I have no installation of music library in Python. So be careful to merge this pull request.
1. In const.jl
`MIDI.Notes` is an abstract type, like Vector. Explicit parameterization is needed. 
2. In split.jl
Use `union!` to join two collections instead of `push!(c1, c2...)`